### PR TITLE
V1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Driver class for the [TMP102](http://www.ti.com.cn/cn/lit/ds/symlink/tmp102.pdf) and [TMP112](http://www.ti.com/lit/ds/symlink/tmp112.pdf) digital temperature sensors. The TMP1x2 class allows you to read the current temperature, as well as configure various interupts.
 
-**To add this library to your project, add `#require "TMP1x2.class.nut:1.0.1"`` to the top of your device code.**
+**To add this library to your project, add `#require "TMP1x2.class.nut:1.0.2"`` to the top of your device code.**
 
-You can view the library’s source code on [GitHub](https://github.com/electricimp/tmp1x2/tree/v1.0.1).
+You can view the library’s source code on [GitHub](https://github.com/electricimp/tmp1x2/tree/v1.0.2).
 
 
 ## Class Usage
@@ -14,7 +14,7 @@ You can view the library’s source code on [GitHub](https://github.com/electric
 To instantiate a new TMP1x2 object, you need to pass in a configured I2C object, and an optional I2C address. If no address is supplied, a default address of ```0x90``` will be use:
 
 ```squirrel
-#require "TMP1x2.class.nut:1.0.1"
+#require "TMP1x2.class.nut:1.0.2"
 
 i2c  <- hardware.i2c89;
 i2c.configure(CLOCK_SPEED_400_KHZ);
@@ -91,7 +91,7 @@ The TMP1x2 class allows you to configure interrupts, however it does not deal wi
 - Configure the interrupt parameters (with *.setHighThreshold()*, *.setLowThreshold())*, *.setModeComparator()*, *.setModeInterrupt()*, *.setActiveHigh()*, and *.setActiveLow()*)
 
 ```squirrel
-#require "TMP1x2.class.nut:1.0.1"
+#require "TMP1x2.class.nut:1.0.2"
 
 // Configure the I2C bus
 i2c  <- hardware.i2c89;
@@ -181,4 +181,3 @@ server.log(tmp.getLowThreshold());
 ## License
 
 The TMP1x2 library is licensed under the [MIT License](https://github.com/electricimp/TMP1x2/blob/master/LICENSE).
- 

--- a/TMP1x2.class.nut
+++ b/TMP1x2.class.nut
@@ -1,6 +1,6 @@
 class TMP1x2 {
 
-    static version = [1, 0, 1];
+    static version = [1, 0, 2];
 
     // Errors
     static TIMEOUT_ERROR = "TMP1x2 conversion timed out";
@@ -53,17 +53,18 @@ class TMP1x2 {
 
             if (cb != null) {
                 // Asynchronous path
+                local boundThis = this;
 
                 // set a timeout callback
                 _conversion_timeout_timer = imp.wakeup(CONVERSION_TIMEOUT, function() {
                     // Failure: cancel polling for a result and call the callback with error
-                    imp.cancelwakeup(_conversion_poll_timer);
-                    _conversion_ready_cb =  null;
-                    imp.wakeup(0, function() { cb({ "err": TMP1x2.TIMEOUT_ERROR, "temp": null }); }.bindenv(this));
+                    imp.cancelwakeup(boundThis._conversion_poll_timer);
+                    boundThis._conversion_ready_cb =  null;
+                    imp.wakeup(0, function() { cb({ "err": TMP1x2.TIMEOUT_ERROR, "temp": null }); });
                 });
 
                 _pollForConversion(function() {
-                    imp.wakeup(0, function() { cb({ "temp": _rawToTemp(_getReg(TEMP_REG)) }); }.bindenv(this));
+                    imp.wakeup(0, function() { cb({ "temp": boundThis._rawToTemp(boundThis._getReg(TEMP_REG)) }); });
                 });
             } else {
                 // Synchronous path
@@ -88,7 +89,7 @@ class TMP1x2 {
         } else {
             local temp = _rawToTemp(_getReg(TEMP_REG));
             if (cb != null) {
-                imp.wakeup(0, function() { cb({ "temp": temp }); }.bindenv(this));
+                imp.wakeup(0, function() { cb({ "temp": temp }); });
                 return;
             }
             return { "temp": temp };


### PR DESCRIPTION
Removed .bindenv(this) for read() callbacks, and explicitly calling internal methods / properties with local copy of this. 
